### PR TITLE
NVMem: fix build issue when FILE_BACKED_NV is set to 0

### DIFF
--- a/TPMCmd/Platform/src/NVMem.c
+++ b/TPMCmd/Platform/src/NVMem.c
@@ -185,6 +185,7 @@ LIB_EXPORT void _plat__NVDisable(
     int delete = ((intptr_t)platParameter != 0)
                      ? TRUE
                      : FALSE;  // IN: If TRUE (!=0), delete the NV contents.
+    NOT_REFERENCED(delete);  // to keep compiler quiet when FILE_BACKED_NV == NO
 
 #if FILE_BACKED_NV
     if(NULL != s_NvFile)


### PR DESCRIPTION
If FILE_BACKED_NV is set to NO(0), the `delete` variable is unused, causing a compiler warning:

    Platform/src/NVMem.c: In function ‘_plat__NVDisable’:
    Platform/src/NVMem.c:185:9: error: unused variable ‘delete’ [-Werror=unused-variable]
      185 |     int delete = ((intptr_t)platParameter != 0)
          |         ^~~~~~
    cc1: all warnings being treated as errors
    make[2]: *** [Makefile:2674: Platform/src/libplatform_a-NVMem.o] Error 1

Use NOT_REFERENCED() to silence this warning.