### PR TITLE
Allow disabling the pthread support check

### DIFF
--- a/TPMCmd/Makefile.am
+++ b/TPMCmd/Makefile.am
@@ -24,12 +24,13 @@ libplatform = Platform/src/libplatform.a
 libtpm = tpm/src/libtpm.a
 tpm2_simulator = Simulator/src/tpm2-simulator
 
-bin_PROGRAMS = $(tpm2_simulator)
 noinst_LIBRARIES = $(libplatform) $(libtpm)
 
 Platform_src_libplatform_a_CFLAGS = $(EXTRA_CFLAGS) $(PLATFORM_INC) $(TPM_INC)
 Platform_src_libplatform_a_SOURCES = $(PLATFORM_C) $(PLATFORM_H) $(TPM_CONFIG_C)
 
+if HAVE_PTHREAD
+bin_PROGRAMS = $(tpm2_simulator)
 Simulator_src_tpm2_simulator_CFLAGS = $(EXTRA_CFLAGS) $(PLATFORM_INC) \
     $(TPM_INC) $(SIMULATOR_INC) $(LIBCRYPTO_CFLAGS) $(PTHREAD_CFLAGS)
 # the weird / duplicate static library is necessary for dealing with the
@@ -37,6 +38,7 @@ Simulator_src_tpm2_simulator_CFLAGS = $(EXTRA_CFLAGS) $(PLATFORM_INC) \
 Simulator_src_tpm2_simulator_LDADD = $(libplatform) $(libtpm) \
     $(libplatform) $(LIBCRYPTO_LIBS) $(PTHREAD_LIBS) @ADDITIONAL_LIBS@
 Simulator_src_tpm2_simulator_SOURCES = $(SIMULATOR_C) $(SIMULATOR_H)
+endif
 
 tpm_src_libtpm_a_CFLAGS = $(EXTRA_CFLAGS) $(PLATFORM_INC) $(TPM_INC) \
     $(LIBCRYPTO_CFLAGS)

--- a/TPMCmd/configure.ac
+++ b/TPMCmd/configure.ac
@@ -38,7 +38,14 @@ AS_IF([test "x$enable_usedeviceid" = "xyes"], [
     PKG_CHECK_MODULES([LIBUDEV], [libudev])
     [ADDITIONAL_LIBS="-ludev"]
 ])
-AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])
+
+AC_ARG_ENABLE([pthread],
+    [AS_HELP_STRING([--disable-pthread], [Disable pthread support (tpm simulator will not be built, but only the libraries)])],
+    [use_pthread=$enableval], [use_pthread=yes])
+AS_IF([test "x$use_pthread" = "xyes"],
+    [AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])],
+    [AC_MSG_NOTICE([pthread support disabled])])
+AM_CONDITIONAL([HAVE_PTHREAD], [test "x$use_pthread" = "xyes"])
 
 AC_DEFINE([HASH_LIB], [Ossl], [Crypto lib for hash algorithms])
 AC_DEFINE([SYM_LIB], [Ossl], [Crypto lib for symmetric encryption algorithms])


### PR DESCRIPTION
Commit 9bc545f ("Squash public changes from v184 development") accidentally reverted this change, so let's re-apply again commit 9df00d43ff5931afd30f84dd9992648c5051d71e (merged with https://github.com/TrustedComputingGroup/TPM/pull/6)

> In cases where this code is utlized only for the libriers in it (e.g. vTPM emulation in Coconut SVSM), we do not need to compile the simulator.
> 
> So it would be convenient to have the ability to disable pthread checking, which in that case is not necassary since it is used only by the simulator. Also in Coconut SVSM we don't have pthread support, so it's also a requirement and for now we have our own fork to disable this check.
> 
> By default pthread checking remains enabled, so there is no change. `--disable-pthread` is added to the configure to support this new use case.